### PR TITLE
Fix CloudFlare deploy action logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,9 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Copy .assetsignore to dist
+        run: cp public/.assetsignore dist/.assetsignore
+
       - name: Deploy to Cloudflare Workers
         id: deploy
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
Wrangler was failing to deploy because the .assetsignore file wasn't present in the dist folder. The file exists in public/ but isn't automatically copied to dist/ during the Astro build process.

This fix adds a step in the deploy job to copy the .assetsignore file from public/ to dist/ before running wrangler deploy. This ensures Wrangler knows to exclude _worker.js from being uploaded as an asset.

Fixes the error:
"Uploading a Pages _worker.js directory as an asset"