### PR TITLE
fix: Improve contact page card layout and alignment

### DIFF
--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -36,7 +36,7 @@
   grid-template-columns: 1fr 1fr;
   gap: 3rem;
   margin-bottom: 4rem;
-  align-items: stretch;
+  align-items: start;
 }
 
 .contact-info {
@@ -49,7 +49,6 @@
   color: var(--text-white);
   display: flex;
   flex-direction: column;
-  height: 100%;
   box-sizing: border-box;
 }
 
@@ -129,9 +128,7 @@
   box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-border);
   display: flex;
   flex-direction: column;
-  height: 100%;
   box-sizing: border-box;
-  overflow: hidden;
 }
 
 .contact-form form {
@@ -353,7 +350,6 @@
   .contact-info,
   .contact-form {
     padding: 2rem;
-    height: auto;
     width: 100%;
     box-sizing: border-box;
   }
@@ -436,7 +432,6 @@
   .contact-info,
   .contact-form {
     padding: 1.5rem;
-    height: auto;
     width: 100%;
     box-sizing: border-box;
   }


### PR DESCRIPTION
- Change grid alignment from stretch to start for natural card heights
- Remove conflicting height: 100% from card containers
- Remove overflow: hidden that was hiding content
- Clean up redundant height: auto in responsive styles