### PR TITLE
ci: run Build & Validate once per PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Build & Validate
 
 on:
-  # Run on all pushes
+  # Run on pushes to main (feature branches are covered by pull_request)
   push:
+    branches:
+      - main
 
   # Run on all pull requests
   pull_request:


### PR DESCRIPTION
## What
Restricts the `push` trigger in `test.yml` to the `main` branch so each PR runs Build & Validate once instead of twice.

## Why
The workflow fired on both `push` (all branches, no filter) and `pull_request`. Every commit to a PR branch matched both events, producing two identical "Build & Validate" runs per push — double the Actions minutes and double the red X's on failing PRs (visible on #81/#82/#83, which each showed two failed runs).

## Changes
- `.github/workflows/test.yml`: `push` trigger now filtered to `branches: [main]`; `pull_request` (all PRs) and `workflow_dispatch` unchanged

Post-merge behavior:
- PR branch commit → one run (`pull_request`)
- Merge to main → one run (`push`)
- Direct push to a branch with no open PR → no run until a PR is opened (standard trade-off of this pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)