### PR TITLE
fix(contact): equalize card heights in two-column layout

### DIFF
--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -36,7 +36,8 @@
   grid-template-columns: 1fr 1fr;
   gap: 3rem;
   margin-bottom: 4rem;
-  align-items: start;
+  /* default align-items: stretch equalizes card heights;
+     the form's textarea flex-grows to absorb the difference */
 }
 
 .contact-info {


### PR DESCRIPTION
## What
Makes the "Get In Touch" and "Send a Message" cards on the contact page equal height in the desktop two-column layout.

## Why
`.contact-container` set `align-items: start`, which forces each grid item to its natural content height — so the form card ended visibly shorter than the info card. The stylesheet already contained the equal-height plumbing (`form { flex: 1 }`, textarea `flex-grow: 1`, `submit-btn { margin-top: auto }`), but the `start` alignment at the grid level defeated it.

## Changes
- `src/styles/contact.css`: remove `align-items: start` from `.contact-container` so the grid default (`stretch`) applies; the message textarea absorbs the height difference (180px → ~356px at desktop width) and the submit button stays pinned to the card bottom

Verified in browser: both cards measure identical height (946px) at desktop width; mobile (<768px) is unchanged since the container switches to a stacked flex column and the textarea returns to its 180px minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)