### PR TITLE
feat: restrict CMS sign-in to the site owner

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 
@@ -16,12 +16,27 @@ export default defineConfig({
     mdx(),
     sitemap(),
     icon(),
-    // Blog editor at /admin (Sveltia CMS UI) with self-hosted GitHub OAuth
-    // at /oauth + /oauth/callback, served by the same Cloudflare Worker.
+    // Blog editor at /admin (Sveltia CMS UI). OAuth routes are implemented
+    // in src/pages/oauth/ instead of the integration's own, so sign-in can
+    // be restricted to the site owner's GitHub account.
     decapCmsOauth({
       decapCMSSrcUrl: "https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js",
+      oauthDisabled: true,
     }),
   ],
+  env: {
+    validateSecrets: true,
+    schema: {
+      OAUTH_GITHUB_CLIENT_ID: envField.string({
+        context: "server",
+        access: "secret",
+      }),
+      OAUTH_GITHUB_CLIENT_SECRET: envField.string({
+        context: "server",
+        access: "secret",
+      }),
+    },
+  },
   adapter: cloudflare(),
   // Enable CSRF protection but allow requests from development and production origins
   security: {

--- a/src/pages/oauth/callback.ts
+++ b/src/pages/oauth/callback.ts
@@ -29,7 +29,11 @@ export const GET: APIRoute = async ({ url }) => {
       throw new Error(`GitHub OAuth error! status: ${response.status}`);
     }
 
-    const body = await response.json();
+    const body = (await response.json()) as {
+      access_token?: string;
+      error?: string;
+      error_description?: string;
+    };
 
     if (body.error || !body.access_token) {
       throw new Error(`GitHub OAuth error: ${body.error_description || body.error || "no access token"}`);
@@ -47,9 +51,9 @@ export const GET: APIRoute = async ({ url }) => {
       throw new Error(`GitHub user lookup failed! status: ${userResponse.status}`);
     }
 
-    const user = await userResponse.json();
+    const user = (await userResponse.json()) as { login?: string };
 
-    if (!ALLOWED_GITHUB_LOGINS.includes(user.login)) {
+    if (!user.login || !ALLOWED_GITHUB_LOGINS.includes(user.login)) {
       return new Response("Access denied: this CMS is restricted to the site owner.", {
         status: 403,
       });

--- a/src/pages/oauth/callback.ts
+++ b/src/pages/oauth/callback.ts
@@ -1,0 +1,86 @@
+import type { APIRoute } from "astro";
+import { OAUTH_GITHUB_CLIENT_ID, OAUTH_GITHUB_CLIENT_SECRET } from "astro:env/server";
+
+export const prerender = false;
+
+// Only these GitHub accounts may sign in to the CMS. Everyone else gets a
+// 403 before any token reaches the browser. (Write access is additionally
+// limited by GitHub repo permissions regardless of this list.)
+const ALLOWED_GITHUB_LOGINS = ["CodeAlanDebug"];
+
+export const GET: APIRoute = async ({ url }) => {
+  const data = {
+    code: url.searchParams.get("code"),
+    client_id: OAUTH_GITHUB_CLIENT_ID,
+    client_secret: OAUTH_GITHUB_CLIENT_SECRET,
+  };
+
+  try {
+    const response = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub OAuth error! status: ${response.status}`);
+    }
+
+    const body = await response.json();
+
+    if (body.error || !body.access_token) {
+      throw new Error(`GitHub OAuth error: ${body.error_description || body.error || "no access token"}`);
+    }
+
+    const userResponse = await fetch("https://api.github.com/user", {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${body.access_token}`,
+        "User-Agent": "alan-one-cms-oauth",
+      },
+    });
+
+    if (!userResponse.ok) {
+      throw new Error(`GitHub user lookup failed! status: ${userResponse.status}`);
+    }
+
+    const user = await userResponse.json();
+
+    if (!ALLOWED_GITHUB_LOGINS.includes(user.login)) {
+      return new Response("Access denied: this CMS is restricted to the site owner.", {
+        status: 403,
+      });
+    }
+
+    const content = {
+      token: body.access_token,
+      provider: "github",
+    };
+
+    const script = `
+      <script>
+        const receiveMessage = (message) => {
+          window.opener.postMessage(
+            'authorization:${content.provider}:success:${JSON.stringify(content)}',
+            message.origin
+          );
+
+          window.removeEventListener("message", receiveMessage, false);
+        }
+        window.addEventListener("message", receiveMessage, false);
+
+        window.opener.postMessage("authorizing:${content.provider}", "*");
+      </script>
+    `;
+
+    return new Response(script, {
+      headers: { "Content-Type": "text/html" },
+    });
+  } catch (err) {
+    console.error(err);
+    return new Response("Authentication failed.", { status: 500 });
+  }
+};

--- a/src/pages/oauth/index.ts
+++ b/src/pages/oauth/index.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import { OAUTH_GITHUB_CLIENT_ID } from "astro:env/server";
+
+export const prerender = false;
+
+export const GET: APIRoute = ({ redirect }) => {
+  const params = new URLSearchParams({
+    client_id: OAUTH_GITHUB_CLIENT_ID,
+    scope: "repo,user",
+  });
+
+  return redirect(`https://github.com/login/oauth/authorize?${params.toString()}`);
+};


### PR DESCRIPTION
## Summary

Follow-up to #89 (this commit was pushed after that PR merged, so it needs its own PR).

Replaces the integration's OAuth routes with local ones in `src/pages/oauth/` that verify GitHub identity after the token exchange: the callback looks up the signed-in user via the GitHub API and only completes the CMS login handshake for allowlisted accounts (`CodeAlanDebug`), returning **403 before any token reaches the browser** for everyone else. Write access was already limited by repo permissions; this closes the sign-in door too.

- `oauthDisabled: true` keeps the integration's `/admin` dashboard; only the auth routes are replaced
- `env` schema moved into `astro.config.mjs`, so build-time validation of `OAUTH_GITHUB_CLIENT_ID`/`OAUTH_GITHUB_CLIENT_SECRET` is unchanged — existing CF/CI vars carry over
- To add an author later: append their GitHub login to `ALLOWED_GITHUB_LOGINS` in `src/pages/oauth/callback.ts` and grant repo access

## Test plan

- [x] `astro check` + `npm run build` pass
- [x] Dev server: `/oauth` redirects to GitHub authorize, `/oauth/callback` fails closed (500, no token handshake) on invalid exchange, `/admin` unaffected
- [ ] Post-merge with real OAuth app: owner sign-in succeeds; second account receives 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)