### PR TITLE
ci: ignore TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
+    ignore:
+      # TypeScript 7 (native/Go port) is not supported by @astrojs/check yet
+      # (peer range: ^5.0.0 || ^6.0.0) — `astro check` crashes on TS 7.
+      # Remove this once Astro tooling supports TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group all Astro-related packages together
       astro:


### PR DESCRIPTION
## Summary

- PR #93 (dev-dependencies group) fails **Build & Validate**: it bumps `typescript` 6.0.3 → 7.0.2, but `@astrojs/check` (latest, 0.9.9) only supports `typescript ^5 || ^6` — `astro check` crashes with `Cannot read properties of undefined (reading 'fileExists')` in `@astrojs/language-server`
- Adds a Dependabot `ignore` rule for `typescript` `version-update:semver-major` so TS stays on 6.x until Astro tooling supports TypeScript 7
- Minor/patch TypeScript updates still flow; the wrangler bump from #93 will be re-delivered when the group PR is recreated

## Test plan

- [x] YAML validated locally
- [ ] After merge: comment `@dependabot recreate` on #93 — regenerated PR should contain only the wrangler bump and pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)